### PR TITLE
Change pacman install commands in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Here we will be using arch linux, you can easily find equivalent commands for yo
 - Open terminal on the location where you downloaded the .whl file
 - Install python3 and dependencies by running following commands on terminal
 ```
-$ sudo pacman -Sy python3 python-pip freerdp
+$ sudo pacman -S python3 python-pip freerdp
 $ pip3 install PyQt5
 ```
 - Install the downloaded .whl file by running
@@ -42,7 +42,7 @@ This will help you set up an efficient virtual machine for use with cassowary.
 
 #### We start by installing virt-manager and KVM
 ```
-$ sudo pacman -Sy virt-manager
+$ sudo pacman -S virt-manager
 ```
 
 #### Making KVM run without root access


### PR DESCRIPTION
Update README as using -Sy is unsupported and could lead to partial updates and other dependency issues. Use -S instead, as recommended by the Arch Wiki. See the [warning](https://wiki.archlinux.org/title/Pacman#Installing_packages) and [Installing specific packages](https://wiki.archlinux.org/title/Pacman#Installing_specific_packages) on the Arch Wiki.