### PR TITLE
Update 3-faq.md

### DIFF
--- a/docs/3-faq.md
+++ b/docs/3-faq.md
@@ -17,7 +17,7 @@ A. Open cassowary on linux, go to **"Folder Mapping"** tab Goto **"Linux->Window
 A. Run:
 
 ```
-$ python3 -m cassowary cassowary -c guest-run --{path to app and arguments}
+$ python3 -m cassowary -c guest-run -- {path to app and arguments}
 ```
 
 ---


### PR DESCRIPTION
Run command repeats "cassowary" twice where it should be written once. Extra whitespace added to separate placeholder from command argument