### PR TITLE
Make libvirtd start automatically on boot.

### DIFF
--- a/docs/1-virt-manager.md
+++ b/docs/1-virt-manager.md
@@ -18,6 +18,7 @@ $ sudo sed -i "s/#group = \"root\"/group = \"$(id -gn)\"/g" /etc/libvirt/qemu.co
 $ sudo usermod -a -G kvm $(id -un)
 $ sudo usermod -a -G libvirt $(id -un)
 $ sudo systemctl restart libvirtd
+$ sudo systemctl enable libvirtd
 $ sudo ln -s /etc/apparmor.d/usr.sbin.libvirtd /etc/apparmor.d/disable/
 ```
 


### PR DESCRIPTION
Helps to reduce confusion on why cassowary isn't working after rebooting.