### PR TITLE
fix: mount command

### DIFF
--- a/app-linux/src/cassowary/base/helper.py
+++ b/app-linux/src/cassowary/base/helper.py
@@ -103,7 +103,7 @@ def mount_pending():
             # actually mount it
             mount_point = os.path.join(cfgvars.config["winshare_mount_root"], expanded_cached_shares[resource_path][1])
             mount = mount + 'mkdir -p {mount_pt} && mount -t cifs -o username="{win_uname}",' \
-                            'password="{win_pass}",uid={uid},gid={gid} "{net_loc}" "{mount_pt}" && '.format(
+                            'password="{win_pass}",uid={uid},gid={gid} \'{net_loc}\' "{mount_pt}" && '.format(
                 win_uname=cfgvars.config["winvm_username"], win_pass=cfgvars.config["winvm_password"],
                 mount_pt=mount_point, net_loc=expanded_cached_shares[resource_path][0], uid=uid, gid=gid
             )

--- a/app-linux/src/cassowary/base/helper.py
+++ b/app-linux/src/cassowary/base/helper.py
@@ -103,11 +103,10 @@ def mount_pending():
             # actually mount it
             mount_point = os.path.join(cfgvars.config["winshare_mount_root"], expanded_cached_shares[resource_path][1])
             mount = mount + 'mkdir -p {mount_pt} && mount -t cifs -o username="{win_uname}",' \
-                            'password="{win_pass}",uid={uid},gid={gid} \'{net_loc}\' "{mount_pt}" && '.format(
+                            'password="{win_pass}",uid={uid},gid={gid} \'{net_loc}\' "{mount_pt}"; '.format(
                 win_uname=cfgvars.config["winvm_username"], win_pass=cfgvars.config["winvm_password"],
                 mount_pt=mount_point, net_loc=expanded_cached_shares[resource_path][0], uid=uid, gid=gid
             )
-    mount = mount[:-4]
     if mount != "":
         logger.debug("Generated mount command: '%s'", mount)
         if os.environ.get("DIALOG_MODE") == "console":


### PR DESCRIPTION
1. net_loc should be wrapped by single quotes, so that `\` will not be treated as the escape character. After this fix, net locations like `\\192.168.1.120\Documents\` are able to be mounted.
2. different mount points should be processed independently (see commit msg of the 2nd commit)