### PR TITLE
New method for finding installed apps for win >= 10, generalized PyInstaller command

### DIFF
--- a/app-win/build.bat
+++ b/app-win/build.bat
@@ -6,7 +6,7 @@ rmdir /s /q dist
 echo ==^> Using pyinstaller to make executable
 python -m ensurepip
 python -m pip install pyinstaller pywin32 icoextract
-pyinstaller package.spec --noconfirm
+python -m PyInstaller package.spec --noconfirm
 echo ==^> Copying to setup directory
 mkdir ..\bin
 Xcopy /E /I /F /Y dist\cassowary ..\bin\cassowary

--- a/app-win/src/base/command/cmd_apps.py
+++ b/app-win/src/base/command/cmd_apps.py
@@ -1,5 +1,9 @@
+import sys
 import os
+import subprocess
+import glob
 import traceback
+import pywintypes
 import winreg
 import win32api
 from base64 import b64encode
@@ -31,6 +35,19 @@ class ApplicationData:
             version = "unknown"
             logger.warning("Failed to get version information for '%s' : %s", path_to_exe, traceback.format_exc())
         return [description, version]
+        
+    @staticmethod
+    def __get_exe_descr(path_to_exe):
+        logger.debug("Getting application descriptions for: '{}' ".format(path_to_exe))
+        try:
+            language, codepage = win32api.GetFileVersionInfo(path_to_exe, '\\VarFileInfo\\Translation')[0]
+            stringFileInfo = u'\\StringFileInfo\\%04X%04X\\%s' % (language, codepage, "FileDescription")
+
+            description = win32api.GetFileVersionInfo(path_to_exe, stringFileInfo)
+            description = ' '.join(description.split('.'))
+        except:
+            description = "unknown"
+        return description
 
     @staticmethod
     def __get_exe_image(exe_path):
@@ -72,17 +89,72 @@ class ApplicationData:
                         logger.error("Exception while scanning for apps ! : "+traceback.format_exc())
                         pass
         return applications
+        
+    @staticmethod
+    def __find_installed_with_info():
+        logger.debug("Getting list of installed applications")
+        applications = []
+        ps_command = "Get-AppxPackage | Select {:s}"
+        fields = ["Name", "Version", "InstallLocation"]
+        applications_dict = {field: [] for field in fields}
+        for field in fields:
+            command = ["powershell.exe", ps_command.format(field)]
+            p = subprocess.Popen(command, stdout=subprocess.PIPE)
+            output, errors = p.communicate()
+            if not errors:
+                for line in output.decode("utf-8").splitlines():
+                    line = line.strip()
+                    if line and (not "---" in line) and (not field in line):
+                        applications_dict[field].append(line)
+            else:
+                logger.error("Exception while scanning for apps ! : "+traceback.format_exc())
+                return applications
+
+        for i, path in enumerate(applications_dict["InstallLocation"]):
+            executables = glob.glob(path + "\\**\\*.exe", recursive=True)
+            n = len(executables)
+            if n == 0:
+                executable = None
+            elif n > 1:
+                executable = None
+                executable_size = 0 
+                for file in executables:
+                    size = os.path.getsize(file)
+                    if size > executable_size:
+                        executable = file
+                        executable_size = size
+            else:
+                executable = executables[0]
+                
+            if executable is not None and not "SystemApps" in executable:
+                if applications_dict["Name"][i] is None:
+                    name = os.basename(executable).split('.')[0]
+                    name = name[0].upper() + name[1:]
+                else:
+                    name = ' '.join(applications_dict["Name"][i].split('.'))
+                applications.append([name, executable, applications_dict["Version"][i]])
+                
+        return applications
 
     def run_cmd(self, cmd):
         if cmd[0] == "get-installed-apps":
             installed_apps = []
             # app_name: [path_to_exe, version, icon ]
-            apps = self.__find_installed()
-            for app in apps:
-                app_info = self.__get_exe_info(app)
-                # NOTE: app_info[0] is app icon remove it from the returned data
-                installed_apps.append([app_info[0], app, app_info[1]])
-                # [description, path, version]
+            if sys.getwindowsversion().major < 10:
+                apps = self.__find_installed()
+                for app in apps:
+                    app_info = self.__get_exe_info(app)
+                    # NOTE: app_info[0] is app icon remove it from the returned data
+                    installed_apps.append([app_info[0], app, app_info[1]])
+                    # [description, path, version]
+            else:
+                apps_with_info = self.__find_installed_with_info()
+                for app_with_info in apps_with_info:
+                    app_descr = self.__get_exe_descr(app_with_info[1])
+                    if app_descr is not None and app_descr != "unknown":
+                        app_with_info[0] = app_descr
+                    installed_apps.append(app_with_info)
+                    # [description, path, version]
             return True, installed_apps
         elif cmd[0] == "get-exe-icon":
             return True, self.__get_exe_image(cmd[1])


### PR DESCRIPTION
Cassowary tries to pull the list of installed apps from the registry. However, under Windows 10, not all apps are listed in the searched registry locations. In this PR, a new method was added using a powershell command to list all installed packages and filtering out the system apps and apps without an executable.
Also, in order to build the application on Windows 11, a change in the build.bat script was necessary to call the PyInstaller properly.