### PR TITLE
Specify the WHL file for the pip install command.

### DIFF
--- a/docs/2-cassowary-install.md
+++ b/docs/2-cassowary-install.md
@@ -25,7 +25,7 @@ $ pip3 install PyQt5
 - Install the downloaded `.whl` file by running:
 
 ```bash
-$ pip install cassowary*
+$ pip install cassowary*.whl
 ```
 
 > If you get any warning about the folder `/home/$USER/.local/bin` not in your PATH, you can easily add it by adding it to your `$HOME/.profile` or `$HOME/.bash_profile`:


### PR DESCRIPTION
Update "[docs/2-cassowary-install.md](https://github.com/casualsnek/cassowary/blob/main/docs/2-cassowary-install.md)".

Avoid installing the ZIP file.

```
ERROR: cassowary-0.6-winsetup.zip does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found.
```